### PR TITLE
Implement validator VM

### DIFF
--- a/chain/app/app.go
+++ b/chain/app/app.go
@@ -17,6 +17,8 @@ import (
 	validatortypes "github.com/example/usdwz/chain/x/validator/types"
 	yieldkeeper "github.com/example/usdwz/chain/x/yield/keeper"
 	yieldtypes "github.com/example/usdwz/chain/x/yield/types"
+
+	"github.com/example/usdwz/chain/vm"
 )
 
 // UsdWzApp is the main application type.
@@ -32,6 +34,9 @@ type UsdWzApp struct {
 	EscrowKeeper     escrowkeeper.Keeper
 	ValidatorKeeper  validatorkeeper.Keeper
 	YieldKeeper      yieldkeeper.Keeper
+
+	// validator scripting VM
+	VM *vm.VM
 }
 
 // New creates a new UsdWzApp instance with basic modules wired.
@@ -58,6 +63,7 @@ func New(logger log.Logger) *UsdWzApp {
 	app.EscrowKeeper = escrowkeeper.NewKeeper(cdc, keys[escrowtypes.StoreKey])
 	app.ValidatorKeeper = validatorkeeper.NewKeeper(cdc, keys[validatortypes.StoreKey])
 	app.YieldKeeper = yieldkeeper.NewKeeper(cdc, keys[yieldtypes.StoreKey])
+	app.VM = vm.New()
 
 	return app
 }

--- a/chain/app/app_test.go
+++ b/chain/app/app_test.go
@@ -38,4 +38,8 @@ func TestKVStoreKey(t *testing.T) {
 	if k1 == k2 {
 		t.Fatal("store keys should be distinct")
 	}
+
+	if a.VM == nil {
+		t.Fatal("vm should initialize")
+	}
 }

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -1,0 +1,89 @@
+package vm
+
+import "strconv"
+
+// Opcode defines a VM instruction.
+type Opcode int
+
+const (
+	OP_SET Opcode = iota
+	OP_ANY
+	OP_QUORUM
+	OP_ALL
+	OP_THEN
+)
+
+// Instruction represents a single VM instruction.
+type Instruction struct {
+	Op  Opcode
+	Arg string
+}
+
+// VM executes validator approval scripts.
+type VM struct{}
+
+// New returns a new VM instance.
+func New() *VM { return &VM{} }
+
+// Validate executes the script against the provided votes and validator sets.
+// Votes map validator IDs to their boolean vote. Sets map set IDs to validator
+// IDs.
+func (vm *VM) Validate(script []Instruction, votes map[string]bool, sets map[string][]string) bool {
+	i := 0
+	for i < len(script) {
+		inst := script[i]
+		if inst.Op != OP_SET {
+			return false
+		}
+		current := sets[inst.Arg]
+		i++
+		if i >= len(script) {
+			return false
+		}
+		// evaluate condition for current set
+		cond := script[i]
+		ok := false
+		switch cond.Op {
+		case OP_ANY:
+			ok = hasAny(current, votes)
+		case OP_QUORUM:
+			n, err := strconv.Atoi(cond.Arg)
+			if err != nil {
+				return false
+			}
+			ok = countYes(current, votes) >= n
+		case OP_ALL:
+			ok = countYes(current, votes) == len(current)
+		default:
+			return false
+		}
+		if !ok {
+			return false
+		}
+		i++
+		if i < len(script) && script[i].Op == OP_THEN {
+			i++
+			continue
+		}
+	}
+	return true
+}
+
+func hasAny(set []string, votes map[string]bool) bool {
+	for _, v := range set {
+		if votes[v] {
+			return true
+		}
+	}
+	return false
+}
+
+func countYes(set []string, votes map[string]bool) int {
+	c := 0
+	for _, v := range set {
+		if votes[v] {
+			c++
+		}
+	}
+	return c
+}

--- a/chain/vm/vm_test.go
+++ b/chain/vm/vm_test.go
@@ -1,0 +1,180 @@
+package vm
+
+import "testing"
+
+func TestVMAny(t *testing.T) {
+	m := New()
+	script := []Instruction{{OP_SET, "A"}, {OP_ANY, ""}}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{"single yes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true}, true},
+		{"all no", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": false, "v2": false}, false},
+		{"two yes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"yes outside set", map[string][]string{"A": {"v1"}}, map[string]bool{"v2": true}, false},
+		{"bigger set one yes", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v2": true}, true},
+		{"bigger set none", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v4": true}, false},
+		{"extra set ignored", map[string][]string{"A": {"v1"}, "B": {"v2"}}, map[string]bool{"v1": true}, true},
+		{"empty set", map[string][]string{"A": []string{}}, map[string]bool{"v1": true}, false},
+		{"repeated yes", map[string][]string{"A": {"v1", "v1"}}, map[string]bool{"v1": true}, true},
+		{"partial votes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v2": false}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := m.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}
+
+func TestVMQuorum(t *testing.T) {
+	m := New()
+	script := []Instruction{{OP_SET, "A"}, {OP_QUORUM, "2"}}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{"exact quorum", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"above quorum", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": true, "v3": true}, true},
+		{"below quorum", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true}, false},
+		{"no votes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{}, false},
+		{"quorum different set", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v3": true, "v4": true}, false},
+		{"large set quorum", map[string][]string{"A": {"v1", "v2", "v3", "v4"}}, map[string]bool{"v1": true, "v4": true}, true},
+		{"mixed votes", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": false, "v3": true}, true},
+		{"duplicate yes", map[string][]string{"A": {"v1", "v1", "v2"}}, map[string]bool{"v1": true}, true},
+		{"empty set", map[string][]string{"A": []string{}}, map[string]bool{"v1": true}, false},
+		{"quorum not reached", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v3": true}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := m.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}
+
+func TestVMAll(t *testing.T) {
+	m := New()
+	script := []Instruction{{OP_SET, "A"}, {OP_ALL, ""}}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{"all yes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"one no", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true, "v2": false}, false},
+		{"missing vote", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true}, false},
+		{"empty set", map[string][]string{"A": []string{}}, map[string]bool{}, true},
+		{"large set all yes", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": true, "v3": true}, true},
+		{"large set one no", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": false, "v3": true}, false},
+		{"yes outside set", map[string][]string{"A": {"v1"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"duplicate validator", map[string][]string{"A": {"v1", "v1"}}, map[string]bool{"v1": true}, true},
+		{"duplicate validator no", map[string][]string{"A": {"v1", "v1"}}, map[string]bool{"v1": false}, false},
+		{"no votes", map[string][]string{"A": {"v1"}}, map[string]bool{}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := m.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}
+
+func TestVMThen(t *testing.T) {
+	m := New()
+	script := []Instruction{
+		{OP_SET, "A"}, {OP_QUORUM, "2"}, {OP_THEN, ""},
+		{OP_SET, "B"}, {OP_ALL, ""},
+	}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{
+			"happy path",
+			map[string][]string{"A": {"v1", "v2", "v3"}, "B": {"v4", "v5"}},
+			map[string]bool{"v1": true, "v2": true, "v4": true, "v5": true},
+			true,
+		},
+		{
+			"fail second",
+			map[string][]string{"A": {"v1", "v2", "v3"}, "B": {"v4", "v5"}},
+			map[string]bool{"v1": true, "v2": true, "v5": true},
+			false,
+		},
+		{
+			"fail first",
+			map[string][]string{"A": {"v1", "v2", "v3"}, "B": {"v4", "v5"}},
+			map[string]bool{"v1": true, "v4": true, "v5": true},
+			false,
+		},
+		{
+			"different sets",
+			map[string][]string{"A": {"x1", "x2"}, "B": {"y1", "y2"}},
+			map[string]bool{"x1": true, "x2": true, "y1": true, "y2": true},
+			true,
+		},
+		{
+			"extra votes",
+			map[string][]string{"A": {"v1", "v2"}, "B": {"v3"}},
+			map[string]bool{"v1": true, "v2": true, "v3": true, "v4": true},
+			true,
+		},
+		{
+			"missing all second",
+			map[string][]string{"A": {"v1", "v2"}, "B": {"v3"}},
+			map[string]bool{"v1": true, "v2": true},
+			false,
+		},
+		{
+			"quorum not met",
+			map[string][]string{"A": {"v1", "v2"}, "B": {"v3"}},
+			map[string]bool{"v1": true, "v3": true},
+			false,
+		},
+		{
+			"duplicate validators",
+			map[string][]string{"A": {"v1", "v1"}, "B": {"v2", "v2"}},
+			map[string]bool{"v1": true, "v2": true},
+			true,
+		},
+		{
+			"empty sets",
+			map[string][]string{"A": []string{}, "B": []string{}},
+			map[string]bool{},
+			false,
+		},
+		{
+			"extra then ignored",
+			map[string][]string{"A": {"v1"}, "B": {"v2"}},
+			map[string]bool{"v1": true, "v2": true},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := m.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}

--- a/tests/integration/validator_vm_test.go
+++ b/tests/integration/validator_vm_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/libs/log"
+
+	"github.com/example/usdwz/chain/app"
+	"github.com/example/usdwz/chain/vm"
+)
+
+func TestIntegrationScriptAny(t *testing.T) {
+	a := app.New(log.NewNopLogger())
+	script := []vm.Instruction{{vm.OP_SET, "A"}, {vm.OP_ANY, ""}}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{"single yes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true}, true},
+		{"all no", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": false, "v2": false}, false},
+		{"two yes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"yes outside set", map[string][]string{"A": {"v1"}}, map[string]bool{"v2": true}, false},
+		{"bigger set one yes", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v2": true}, true},
+		{"bigger set none", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v4": true}, false},
+		{"extra set ignored", map[string][]string{"A": {"v1"}, "B": {"v2"}}, map[string]bool{"v1": true}, true},
+		{"empty set", map[string][]string{"A": []string{}}, map[string]bool{"v1": true}, false},
+		{"repeated yes", map[string][]string{"A": {"v1", "v1"}}, map[string]bool{"v1": true}, true},
+		{"partial votes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v2": false}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := a.VM.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}
+
+func TestIntegrationScriptQuorum(t *testing.T) {
+	a := app.New(log.NewNopLogger())
+	script := []vm.Instruction{{vm.OP_SET, "A"}, {vm.OP_QUORUM, "2"}}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{"exact quorum", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"above quorum", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": true, "v3": true}, true},
+		{"below quorum", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true}, false},
+		{"no votes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{}, false},
+		{"quorum different set", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v3": true, "v4": true}, false},
+		{"large set quorum", map[string][]string{"A": {"v1", "v2", "v3", "v4"}}, map[string]bool{"v1": true, "v4": true}, true},
+		{"mixed votes", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": false, "v3": true}, true},
+		{"duplicate yes", map[string][]string{"A": {"v1", "v1", "v2"}}, map[string]bool{"v1": true}, true},
+		{"empty set", map[string][]string{"A": []string{}}, map[string]bool{"v1": true}, false},
+		{"quorum not reached", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v3": true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := a.VM.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}
+
+func TestIntegrationScriptAll(t *testing.T) {
+	a := app.New(log.NewNopLogger())
+	script := []vm.Instruction{{vm.OP_SET, "A"}, {vm.OP_ALL, ""}}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{"all yes", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"one no", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true, "v2": false}, false},
+		{"missing vote", map[string][]string{"A": {"v1", "v2"}}, map[string]bool{"v1": true}, false},
+		{"empty set", map[string][]string{"A": []string{}}, map[string]bool{}, true},
+		{"large set all yes", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": true, "v3": true}, true},
+		{"large set one no", map[string][]string{"A": {"v1", "v2", "v3"}}, map[string]bool{"v1": true, "v2": false, "v3": true}, false},
+		{"yes outside set", map[string][]string{"A": {"v1"}}, map[string]bool{"v1": true, "v2": true}, true},
+		{"duplicate validator", map[string][]string{"A": {"v1", "v1"}}, map[string]bool{"v1": true}, true},
+		{"duplicate validator no", map[string][]string{"A": {"v1", "v1"}}, map[string]bool{"v1": false}, false},
+		{"no votes", map[string][]string{"A": {"v1"}}, map[string]bool{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := a.VM.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}
+
+func TestIntegrationScriptThen(t *testing.T) {
+	a := app.New(log.NewNopLogger())
+	script := []vm.Instruction{
+		{vm.OP_SET, "A"}, {vm.OP_QUORUM, "2"}, {vm.OP_THEN, ""},
+		{vm.OP_SET, "B"}, {vm.OP_ALL, ""},
+	}
+	cases := []struct {
+		name  string
+		sets  map[string][]string
+		votes map[string]bool
+		pass  bool
+	}{
+		{
+			"happy path",
+			map[string][]string{"A": {"v1", "v2", "v3"}, "B": {"v4", "v5"}},
+			map[string]bool{"v1": true, "v2": true, "v4": true, "v5": true},
+			true,
+		},
+		{
+			"fail second",
+			map[string][]string{"A": {"v1", "v2", "v3"}, "B": {"v4", "v5"}},
+			map[string]bool{"v1": true, "v2": true, "v5": true},
+			false,
+		},
+		{
+			"fail first",
+			map[string][]string{"A": {"v1", "v2", "v3"}, "B": {"v4", "v5"}},
+			map[string]bool{"v1": true, "v4": true, "v5": true},
+			false,
+		},
+		{
+			"different sets",
+			map[string][]string{"A": {"x1", "x2"}, "B": {"y1", "y2"}},
+			map[string]bool{"x1": true, "x2": true, "y1": true, "y2": true},
+			true,
+		},
+		{
+			"extra votes",
+			map[string][]string{"A": {"v1", "v2"}, "B": {"v3"}},
+			map[string]bool{"v1": true, "v2": true, "v3": true, "v4": true},
+			true,
+		},
+		{
+			"missing all second",
+			map[string][]string{"A": {"v1", "v2"}, "B": {"v3"}},
+			map[string]bool{"v1": true, "v2": true},
+			false,
+		},
+		{
+			"quorum not met",
+			map[string][]string{"A": {"v1", "v2"}, "B": {"v3"}},
+			map[string]bool{"v1": true, "v3": true},
+			false,
+		},
+		{
+			"duplicate validators",
+			map[string][]string{"A": {"v1", "v1"}, "B": {"v2", "v2"}},
+			map[string]bool{"v1": true, "v2": true},
+			true,
+		},
+		{
+			"empty sets",
+			map[string][]string{"A": []string{}, "B": []string{}},
+			map[string]bool{},
+			false,
+		},
+		{
+			"extra then ignored",
+			map[string][]string{"A": {"v1"}, "B": {"v2"}},
+			map[string]bool{"v1": true, "v2": true},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := a.VM.Validate(script, tc.votes, tc.sets)
+			if res != tc.pass {
+				t.Fatalf("expect %v got %v", tc.pass, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a simple VM package implementing OP_SET, OP_ANY, OP_QUORUM, OP_ALL, OP_THEN
- wire the VM into the app and expose it to modules
- test VM opcode logic
- test VM initialization in app
- cover the four approval scripts with 10 subtests each in unit and integration tests

## Testing
- `go vet ./...`
- `go test ./...`
- `go test -tags=integration ./tests/integration`


------
https://chatgpt.com/codex/tasks/task_e_6879341fcfcc83338f17e383c092a9b0