### PR TITLE
Add functional tests for modules

### DIFF
--- a/chain/cmd/usdwzd/root.go
+++ b/chain/cmd/usdwzd/root.go
@@ -2,6 +2,7 @@ package main
 
 import "github.com/spf13/cobra"
 
+// DefaultNodeHome defines the daemon's home directory used if none is provided.
 const DefaultNodeHome = ".usdWz"
 
 func newRootCmd() *cobra.Command {

--- a/chain/cmd/usdwzd/root_test.go
+++ b/chain/cmd/usdwzd/root_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestNewRootCmd(t *testing.T) {
+	cmd := newRootCmd()
+	if cmd.Use != "usdwzd" {
+		t.Fatalf("expected use 'usdwzd' got %s", cmd.Use)
+	}
+}
+
+func TestDefaultNodeHome(t *testing.T) {
+	if DefaultNodeHome == "" {
+		t.Fatal("default node home should not be empty")
+	}
+}

--- a/chain/x/audit/keeper/keeper.go
+++ b/chain/x/audit/keeper/keeper.go
@@ -36,3 +36,32 @@ func (k Keeper) PublishAttestation(ctx sdk.Context, hash string) error {
 	store.Set(key, bz)
 	return nil
 }
+
+// GetAttestation retrieves an attestation by hash.
+func (k Keeper) GetAttestation(ctx sdk.Context, hash string) (types.Attestation, bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get([]byte("attestation:" + hash))
+	if bz == nil {
+		return types.Attestation{}, false
+	}
+	var att types.Attestation
+	if err := json.Unmarshal(bz, &att); err != nil {
+		return types.Attestation{}, false
+	}
+	return att, true
+}
+
+// ListAttestations returns all stored attestations.
+func (k Keeper) ListAttestations(ctx sdk.Context) []types.Attestation {
+	store := ctx.KVStore(k.storeKey)
+	it := sdk.KVStorePrefixIterator(store, []byte("attestation:"))
+	defer it.Close()
+	var out []types.Attestation
+	for ; it.Valid(); it.Next() {
+		var att types.Attestation
+		if err := json.Unmarshal(it.Value(), &att); err == nil {
+			out = append(out, att)
+		}
+	}
+	return out
+}

--- a/chain/x/audit/keeper/keeper_test.go
+++ b/chain/x/audit/keeper/keeper_test.go
@@ -30,3 +30,65 @@ func TestPublishAttestation(t *testing.T) {
 		t.Fatal("attestation not stored")
 	}
 }
+
+func TestAttestationQueries(t *testing.T) {
+	key := storetypes.NewKVStoreKey("audit")
+	ctx := setupContext(key)
+	k := NewKeeper(nil, key)
+
+	_ = k.PublishAttestation(ctx, "h1")
+	att, ok := k.GetAttestation(ctx, "h1")
+	if !ok || att.Hash != "h1" {
+		t.Fatal("get attestation failed")
+	}
+	if _, ok := k.GetAttestation(ctx, "missing"); ok {
+		t.Fatal("expect missing attestation")
+	}
+
+	_ = k.PublishAttestation(ctx, "h2")
+	list := k.ListAttestations(ctx)
+	if len(list) != 2 {
+		t.Fatalf("expected 2 got %d", len(list))
+	}
+}
+
+func TestAttestationScenarios(t *testing.T) {
+	key := storetypes.NewKVStoreKey("audit")
+	ctx := setupContext(key)
+	k := NewKeeper(nil, key)
+
+	cases := []struct {
+		name string
+		hash string
+	}{
+		{"simple", "a1"},
+		{"empty", ""},
+		{"numbers", "123"},
+		{"symbols", "@@"},
+		{"long", "0123456789abcdef"},
+		{"unicode", "测试"},
+		{"spaces", "hash with space"},
+		{"repeat", "dup"},
+		{"repeat-second", "dup"},
+		{"final", "end"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = k.PublishAttestation(ctx, tc.hash)
+			if _, ok := k.GetAttestation(ctx, tc.hash); !ok {
+				t.Fatalf("attestation %s missing", tc.hash)
+			}
+		})
+	}
+	unique := 0
+	seen := map[string]bool{}
+	for _, c := range cases {
+		if !seen[c.hash] {
+			seen[c.hash] = true
+			unique++
+		}
+	}
+	if len(k.ListAttestations(ctx)) != unique {
+		t.Fatal("list length mismatch")
+	}
+}

--- a/chain/x/audit/module_test.go
+++ b/chain/x/audit/module_test.go
@@ -1,0 +1,17 @@
+package audit
+
+import "testing"
+
+func TestModuleName(t *testing.T) {
+	var m AppModuleBasic
+	if m.Name() != "audit" {
+		t.Fatalf("expected audit got %s", m.Name())
+	}
+}
+
+func TestDefaultGenesis(t *testing.T) {
+	var m AppModuleBasic
+	if string(m.DefaultGenesis(nil)) != "{}" {
+		t.Fatal("default genesis should be empty JSON")
+	}
+}

--- a/chain/x/audit/types/types_test.go
+++ b/chain/x/audit/types/types_test.go
@@ -1,0 +1,16 @@
+package types
+
+import "testing"
+
+func TestModuleName(t *testing.T) {
+	if ModuleName != "audit" {
+		t.Fatalf("expected audit got %s", ModuleName)
+	}
+}
+
+func TestAttestation(t *testing.T) {
+	a := Attestation{Timestamp: 1, Hash: "abc"}
+	if a.Timestamp != 1 || a.Hash != "abc" {
+		t.Fatal("attestation fields not assigned")
+	}
+}

--- a/chain/x/escrow/keeper/keeper.go
+++ b/chain/x/escrow/keeper/keeper.go
@@ -1,8 +1,12 @@
 package keeper
 
 import (
+	"encoding/json"
+	"errors"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/example/usdwz/chain/x/escrow/types"
 )
@@ -17,3 +21,56 @@ func NewKeeper(cdc codec.BinaryCodec, key *storetypes.KVStoreKey) Keeper {
 }
 
 func ModuleName() string { return types.ModuleName }
+
+// CreateEscrow stores a new escrow entry.
+func (k Keeper) CreateEscrow(ctx sdk.Context, id string, amt sdk.Int) {
+	e := types.Escrow{Amount: amt, Completed: false}
+	bz, _ := json.Marshal(e)
+	ctx.KVStore(k.storeKey).Set([]byte("escrow:"+id), bz)
+}
+
+// FinalizeEscrow marks an escrow as completed.
+func (k Keeper) FinalizeEscrow(ctx sdk.Context, id string) error {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get([]byte("escrow:" + id))
+	if bz == nil {
+		return errors.New("not found")
+	}
+	var e types.Escrow
+	_ = json.Unmarshal(bz, &e)
+	e.Completed = true
+	bz, _ = json.Marshal(e)
+	store.Set([]byte("escrow:"+id), bz)
+	return nil
+}
+
+// GetEscrow retrieves an escrow record by id.
+func (k Keeper) GetEscrow(ctx sdk.Context, id string) (types.Escrow, bool) {
+	bz := ctx.KVStore(k.storeKey).Get([]byte("escrow:" + id))
+	if bz == nil {
+		return types.Escrow{}, false
+	}
+	var e types.Escrow
+	_ = json.Unmarshal(bz, &e)
+	return e, true
+}
+
+// DeleteEscrow removes an escrow record.
+func (k Keeper) DeleteEscrow(ctx sdk.Context, id string) {
+	ctx.KVStore(k.storeKey).Delete([]byte("escrow:" + id))
+}
+
+// ListEscrows returns all escrows.
+func (k Keeper) ListEscrows(ctx sdk.Context) []types.Escrow {
+	store := ctx.KVStore(k.storeKey)
+	it := sdk.KVStorePrefixIterator(store, []byte("escrow:"))
+	defer it.Close()
+	var out []types.Escrow
+	for ; it.Valid(); it.Next() {
+		var e types.Escrow
+		if err := json.Unmarshal(it.Value(), &e); err == nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/chain/x/escrow/keeper/keeper_test.go
+++ b/chain/x/escrow/keeper/keeper_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/example/usdwz/chain/x/escrow/types"
+	stablecoinkeeper "github.com/example/usdwz/chain/x/stablecoin/keeper"
 )
 
 func TestNewKeeper(t *testing.T) {
@@ -18,5 +21,75 @@ func TestNewKeeper(t *testing.T) {
 func TestModuleName(t *testing.T) {
 	if ModuleName() != types.ModuleName {
 		t.Fatalf("expected %s got %s", types.ModuleName, ModuleName())
+	}
+}
+
+func TestEscrowLifecycle(t *testing.T) {
+	key := storetypes.NewKVStoreKey("escrow")
+	k := NewKeeper(nil, key)
+	ctx := stablecoinkeeper.TestContext(key) // reuse helper
+
+	k.CreateEscrow(ctx, "e1", sdk.NewInt(10))
+	e, ok := k.GetEscrow(ctx, "e1")
+	if !ok || !e.Amount.Equal(sdk.NewInt(10)) {
+		t.Fatal("escrow not stored")
+	}
+	if e.Completed {
+		t.Fatal("should not be completed")
+	}
+	if err := k.FinalizeEscrow(ctx, "e1"); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+	e, _ = k.GetEscrow(ctx, "e1")
+	if !e.Completed {
+		t.Fatal("escrow not finalized")
+	}
+	k.DeleteEscrow(ctx, "e1")
+	if _, ok := k.GetEscrow(ctx, "e1"); ok {
+		t.Fatal("escrow should be deleted")
+	}
+}
+
+func TestEscrowList(t *testing.T) {
+	key := storetypes.NewKVStoreKey("escrow")
+	k := NewKeeper(nil, key)
+	ctx := stablecoinkeeper.TestContext(key)
+
+	ids := []string{"a", "b", "c"}
+	for i, id := range ids {
+		k.CreateEscrow(ctx, id, sdk.NewInt(int64(i)))
+	}
+	esc := k.ListEscrows(ctx)
+	if len(esc) != len(ids) {
+		t.Fatalf("expected %d got %d", len(ids), len(esc))
+	}
+}
+
+func TestEscrowEdgeCases(t *testing.T) {
+	key := storetypes.NewKVStoreKey("escrow")
+	k := NewKeeper(nil, key)
+	ctx := stablecoinkeeper.TestContext(key)
+
+	cases := []struct {
+		id  string
+		amt sdk.Int
+	}{
+		{"zero", sdk.ZeroInt()},
+		{"negative", sdk.NewInt(-1)},
+		{"big", sdk.NewInt(1000)},
+		{"dup", sdk.OneInt()},
+		{"dup", sdk.NewInt(2)},
+		{"spaces id", sdk.NewInt(3)},
+		{"unicode☃", sdk.NewInt(4)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			k.CreateEscrow(ctx, tc.id, tc.amt)
+			esc, _ := k.GetEscrow(ctx, tc.id)
+			if !esc.Amount.Equal(tc.amt) {
+				t.Fatalf("amt mismatch %s", tc.id)
+			}
+		})
 	}
 }

--- a/chain/x/escrow/module_test.go
+++ b/chain/x/escrow/module_test.go
@@ -1,0 +1,22 @@
+package escrow_test
+
+import (
+	"testing"
+
+	"github.com/example/usdwz/chain/x/escrow"
+	"github.com/example/usdwz/chain/x/escrow/keeper"
+	"github.com/example/usdwz/chain/x/escrow/types"
+)
+
+func TestModuleName(t *testing.T) {
+	if keeper.ModuleName() != types.ModuleName {
+		t.Fatalf("expected %s got %s", types.ModuleName, keeper.ModuleName())
+	}
+}
+
+func TestDefaultGenesis(t *testing.T) {
+	var m escrow.AppModuleBasic
+	if string(m.DefaultGenesis(nil)) != "{}" {
+		t.Fatal("default genesis should be empty JSON")
+	}
+}

--- a/chain/x/escrow/types/types.go
+++ b/chain/x/escrow/types/types.go
@@ -1,6 +1,14 @@
 package types
 
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
 const (
 	ModuleName = "escrow"
 	StoreKey   = ModuleName
 )
+
+// Escrow represents a simple escrow record.
+type Escrow struct {
+	Amount    sdk.Int `json:"amount"`
+	Completed bool    `json:"completed"`
+}

--- a/chain/x/escrow/types/types_test.go
+++ b/chain/x/escrow/types/types_test.go
@@ -1,0 +1,9 @@
+package types
+
+import "testing"
+
+func TestModuleName(t *testing.T) {
+	if ModuleName != "escrow" {
+		t.Fatalf("expected escrow got %s", ModuleName)
+	}
+}

--- a/chain/x/stablecoin/module_test.go
+++ b/chain/x/stablecoin/module_test.go
@@ -1,0 +1,22 @@
+package stablecoin_test
+
+import (
+	"testing"
+
+	"github.com/example/usdwz/chain/x/stablecoin"
+	"github.com/example/usdwz/chain/x/stablecoin/keeper"
+	"github.com/example/usdwz/chain/x/stablecoin/types"
+)
+
+func TestModuleName(t *testing.T) {
+	if keeper.ModuleName() != types.ModuleName {
+		t.Fatalf("expected %s got %s", types.ModuleName, keeper.ModuleName())
+	}
+}
+
+func TestDefaultGenesis(t *testing.T) {
+	var m stablecoin.AppModuleBasic
+	if string(m.DefaultGenesis(nil)) != "{}" {
+		t.Fatal("default genesis should be empty JSON")
+	}
+}

--- a/chain/x/stablecoin/types/types_test.go
+++ b/chain/x/stablecoin/types/types_test.go
@@ -1,0 +1,9 @@
+package types
+
+import "testing"
+
+func TestModuleName(t *testing.T) {
+	if ModuleName != "stablecoin" {
+		t.Fatalf("expected stablecoin got %s", ModuleName)
+	}
+}

--- a/chain/x/validator/keeper/keeper.go
+++ b/chain/x/validator/keeper/keeper.go
@@ -1,8 +1,11 @@
 package keeper
 
 import (
+	"strconv"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/example/usdwz/chain/x/validator/types"
 )
@@ -17,3 +20,36 @@ func NewKeeper(cdc codec.BinaryCodec, key *storetypes.KVStoreKey) Keeper {
 }
 
 func ModuleName() string { return types.ModuleName }
+
+// SubmitVote records a validator vote.
+func (k Keeper) SubmitVote(ctx sdk.Context, val string, approve bool) {
+	ctx.KVStore(k.storeKey).Set([]byte("vote:"+val), []byte(strconv.FormatBool(approve)))
+}
+
+// Vote returns a stored vote.
+func (k Keeper) Vote(ctx sdk.Context, val string) (bool, bool) {
+	bz := ctx.KVStore(k.storeKey).Get([]byte("vote:" + val))
+	if bz == nil {
+		return false, false
+	}
+	b, err := strconv.ParseBool(string(bz))
+	if err != nil {
+		return false, false
+	}
+	return b, true
+}
+
+// Tally returns counts of yes and no votes.
+func (k Keeper) Tally(ctx sdk.Context) (yes, no int) {
+	it := sdk.KVStorePrefixIterator(ctx.KVStore(k.storeKey), []byte("vote:"))
+	defer it.Close()
+	for ; it.Valid(); it.Next() {
+		b, _ := strconv.ParseBool(string(it.Value()))
+		if b {
+			yes++
+		} else {
+			no++
+		}
+	}
+	return
+}

--- a/chain/x/validator/keeper/keeper_test.go
+++ b/chain/x/validator/keeper/keeper_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+
+	stablecoinkeeper "github.com/example/usdwz/chain/x/stablecoin/keeper"
 	"github.com/example/usdwz/chain/x/validator/types"
 )
 
@@ -18,5 +20,51 @@ func TestNewKeeper(t *testing.T) {
 func TestModuleName(t *testing.T) {
 	if ModuleName() != types.ModuleName {
 		t.Fatalf("expected %s got %s", types.ModuleName, ModuleName())
+	}
+}
+
+func TestVoting(t *testing.T) {
+	key := storetypes.NewKVStoreKey("validator")
+	k := NewKeeper(nil, key)
+	ctx := stablecoinkeeper.TestContext(key)
+
+	k.SubmitVote(ctx, "v1", true)
+	v, ok := k.Vote(ctx, "v1")
+	if !ok || !v {
+		t.Fatal("vote not stored")
+	}
+	k.SubmitVote(ctx, "v2", false)
+	yes, no := k.Tally(ctx)
+	if yes != 1 || no != 1 {
+		t.Fatalf("unexpected tally %d/%d", yes, no)
+	}
+}
+
+func TestVoteEdgeCases(t *testing.T) {
+	key := storetypes.NewKVStoreKey("validator")
+	k := NewKeeper(nil, key)
+	ctx := stablecoinkeeper.TestContext(key)
+
+	cases := []struct {
+		id  string
+		val bool
+	}{
+		{"dup", true},
+		{"dup", false},
+		{"missing", false},
+		{"unicode☃", true},
+		{"long", true},
+		{"upper", false},
+		{"", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			k.SubmitVote(ctx, tc.id, tc.val)
+			v, _ := k.Vote(ctx, tc.id)
+			if v != tc.val {
+				t.Fatalf("vote mismatch for %s", tc.id)
+			}
+		})
 	}
 }

--- a/chain/x/validator/module_test.go
+++ b/chain/x/validator/module_test.go
@@ -1,0 +1,22 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/example/usdwz/chain/x/validator"
+	"github.com/example/usdwz/chain/x/validator/keeper"
+	"github.com/example/usdwz/chain/x/validator/types"
+)
+
+func TestModuleName(t *testing.T) {
+	if keeper.ModuleName() != types.ModuleName {
+		t.Fatalf("expected %s got %s", types.ModuleName, keeper.ModuleName())
+	}
+}
+
+func TestDefaultGenesis(t *testing.T) {
+	var m validator.AppModuleBasic
+	if string(m.DefaultGenesis(nil)) != "{}" {
+		t.Fatal("default genesis should be empty JSON")
+	}
+}

--- a/chain/x/validator/types/types_test.go
+++ b/chain/x/validator/types/types_test.go
@@ -1,0 +1,9 @@
+package types
+
+import "testing"
+
+func TestModuleName(t *testing.T) {
+	if ModuleName != "validator" {
+		t.Fatalf("expected validator got %s", ModuleName)
+	}
+}

--- a/chain/x/yield/keeper/keeper.go
+++ b/chain/x/yield/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/example/usdwz/chain/x/yield/types"
 )
@@ -17,3 +18,35 @@ func NewKeeper(cdc codec.BinaryCodec, key *storetypes.KVStoreKey) Keeper {
 }
 
 func ModuleName() string { return types.ModuleName }
+
+var yieldKey = []byte("yield")
+
+// Accrue adds new yield amount.
+func (k Keeper) Accrue(ctx sdk.Context, amt sdk.Int) {
+	y := k.getInt(ctx)
+	y = y.Add(amt)
+	k.setInt(ctx, y)
+}
+
+// Distribute returns accrued yield and resets it.
+func (k Keeper) Distribute(ctx sdk.Context) sdk.Int {
+	y := k.getInt(ctx)
+	k.setInt(ctx, sdk.ZeroInt())
+	return y
+}
+
+// Accrued returns current accrued yield.
+func (k Keeper) Accrued(ctx sdk.Context) sdk.Int { return k.getInt(ctx) }
+
+func (k Keeper) getInt(ctx sdk.Context) sdk.Int {
+	bz := ctx.KVStore(k.storeKey).Get(yieldKey)
+	if bz == nil {
+		return sdk.ZeroInt()
+	}
+	i, _ := sdk.NewIntFromString(string(bz))
+	return i
+}
+
+func (k Keeper) setInt(ctx sdk.Context, v sdk.Int) {
+	ctx.KVStore(k.storeKey).Set(yieldKey, []byte(v.String()))
+}

--- a/chain/x/yield/keeper/keeper_test.go
+++ b/chain/x/yield/keeper/keeper_test.go
@@ -1,0 +1,59 @@
+package keeper
+
+import (
+	"fmt"
+	"testing"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	stablecoinkeeper "github.com/example/usdwz/chain/x/stablecoin/keeper"
+	"github.com/example/usdwz/chain/x/yield/types"
+)
+
+func TestNewKeeper(t *testing.T) {
+	key := storetypes.NewKVStoreKey("yield")
+	k := NewKeeper(nil, key)
+	if k.storeKey != key {
+		t.Fatal("store key mismatch")
+	}
+}
+
+func TestModuleName(t *testing.T) {
+	if ModuleName() != types.ModuleName {
+		t.Fatalf("expected %s got %s", types.ModuleName, ModuleName())
+	}
+}
+
+func TestAccrueAndDistribute(t *testing.T) {
+	key := storetypes.NewKVStoreKey("yield")
+	k := NewKeeper(nil, key)
+	ctx := stablecoinkeeper.TestContext(key)
+
+	k.Accrue(ctx, sdk.NewInt(5))
+	if !k.Accrued(ctx).Equal(sdk.NewInt(5)) {
+		t.Fatal("accrue failed")
+	}
+	k.Accrue(ctx, sdk.NewInt(3))
+	if !k.Accrued(ctx).Equal(sdk.NewInt(8)) {
+		t.Fatal("second accrue failed")
+	}
+	dist := k.Distribute(ctx)
+	if !dist.Equal(sdk.NewInt(8)) || !k.Accrued(ctx).IsZero() {
+		t.Fatal("distribute incorrect")
+	}
+}
+
+func TestYieldEdgeCases(t *testing.T) {
+	key := storetypes.NewKVStoreKey("yield")
+	k := NewKeeper(nil, key)
+	ctx := stablecoinkeeper.TestContext(key)
+
+	cases := []sdk.Int{sdk.ZeroInt(), sdk.NewInt(-1), sdk.NewInt(100)}
+	for i, amt := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			k.Accrue(ctx, amt)
+			_ = k.Distribute(ctx)
+		})
+	}
+}

--- a/chain/x/yield/types/types_test.go
+++ b/chain/x/yield/types/types_test.go
@@ -1,0 +1,9 @@
+package types
+
+import "testing"
+
+func TestModuleName(t *testing.T) {
+	if ModuleName != "yield" {
+		t.Fatalf("expected yield got %s", ModuleName)
+	}
+}


### PR DESCRIPTION
## Summary
- extend audit keeper with retrieval functions and functional tests
- implement simple escrow logic and tests
- add vote handling in validator keeper with tests
- manage accrued yield and tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a59dc47e88333ba2e688773c80e23